### PR TITLE
Bugfix: Create new document repository

### DIFF
--- a/src/screens/DocRepoCreate.vue
+++ b/src/screens/DocRepoCreate.vue
@@ -38,7 +38,7 @@ const { onEvent } = useEventBus()
 const nameInput = ref(null)
 const name = ref('')
 const engine = ref('openai')
-const model = ref('text-embedding-ada-002')
+const model = ref('')
 
 onMounted(() => {
   onEvent('open-docrepo-create', onOpen)


### PR DESCRIPTION
Fixes the error when creating a new document repository (RAG) if no embedding model was selected.
The error occurs when no OpenAI API key has been stored.