### PR TITLE
Add Deepseek R1 <think> tag display support for Chat Message

### DIFF
--- a/css/themes/conversation.css
+++ b/css/themes/conversation.css
@@ -35,3 +35,10 @@
 .message.assistant .actions {
   top: 0px;
 }
+
+div.think {
+  font-style: italic;
+  display: block;
+  margin: 8px 0;
+  color: #666;
+}

--- a/src/components/MessageItemBody.vue
+++ b/src/components/MessageItemBody.vue
@@ -100,8 +100,18 @@ const mdRender = (content: string) => {
     content = content.replace(regex, (match) => `==${match}==`);
   }
 
+  // HACK: dealing with <think> tag from reasoning model like Deepseek R1
+  var html = window.api.markdown.render(content)
+  // append html with '</think>' if there is <think> in html but no '</think>'
+  if (html.includes('<think>') && !html.includes('</think>')) {
+    console.log('appending </think>')
+    html += '</think>'
+  }
+  // replace <think> with <div class="think"> and </think> with </div>
+  html = html.replace(/<think>/g, '<div class="think">').replace(/<\/think>/g, '</div>')
+
   // do it
-  return window.api.markdown.render(content)
+  return html
 }
 
 </script>

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -57,3 +57,9 @@ test('renders block math', () => {
   const html = renderMarkdown(markdown)
   expect(html).toContain('θ')
 })
+
+test('render <think>', () => {
+  const markdown = '<think>Thinking</think>Talking'
+  const html = renderMarkdown(markdown)
+  expect(html).toContain('<p><think>Thinking</think>Talking</p>')
+})


### PR DESCRIPTION
Make the <think> content grey and Italic to differentiate from the rest of the result in chat message. 

