### PR TITLE
Modify uniqueToolName for compatibility with MistralAI API

### DIFF
--- a/src/main/mcp.ts
+++ b/src/main/mcp.ts
@@ -404,7 +404,7 @@ export default class {
       throw new Error(`Tool ${name} not found`)
     }
 
-    const tool = name.replace(`___${client.server.uuid}`, '')
+    const tool = name.replace(`___${client.server.uuid.slice(-4)}`, '')
     console.log('Calling MCP tool', tool, args)
 
     return await client.client.callTool({
@@ -416,7 +416,7 @@ export default class {
 
   protected uniqueToolName(server: McpServer, name: string): string {
   const suffix = server.uuid.slice(-4)  // use only last 4 characters of UUID to generate uniqueToolName
-  return `${name}_${suffix}`
+  return `${name}___${suffix}`
 }
 
   protected mcpToOpenAI = (server: McpServer, tool: any): LlmTool => {

--- a/src/main/mcp.ts
+++ b/src/main/mcp.ts
@@ -415,8 +415,9 @@ export default class {
   }
 
   protected uniqueToolName(server: McpServer, name: string): string {
-    return `${name}___${server.uuid}`
-  }
+  const suffix = server.uuid.slice(-4)  // use only last 4 characters of UUID to generate uniqueToolName
+  return `${name}_${suffix}`
+}
 
   protected mcpToOpenAI = (server: McpServer, tool: any): LlmTool => {
     return {


### PR DESCRIPTION
I ran into an issue while trying to use MCP servers with mistral-large through LiteLLM. It returned this error message:
```json
{
  "error": {
    "message": "litellm.BadRequestError: MistralException - Function name was add_newam_task_with_due_date___8c498bee-e833-49a9-8a88-0ab59fa26cb8 but must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.. Received Model Group=mistral/mistral-large-latest\nAvailable Model Group Fallbacks=None",
    "type": "invalid_request_error",
    "param": null,
    "code": "400"
  }
}
```
This was caused by `uniqueToolName` adding the server UUID to the tool name, which put it over 64 characters. I have adapted `uniqueToolName` to only include the last 4 characters of the server UUID to fix the issue and maintain unique tool names.