### PR TITLE
Fix for Unintended Submission When Using Mac Japanese IME

### DIFF
--- a/src/components/Prompt.vue
+++ b/src/components/Prompt.vue
@@ -626,6 +626,7 @@ let draftPrompt = ''
 const onKeyDown = (event: KeyboardEvent) => {
 
   if (event.key === 'Enter') {
+    if (event.isComposing) return;
     if (event.shiftKey) {
 
     } else {


### PR DESCRIPTION
When typing in Japanese, users type their prompt using romaji (like "konnichiwa"), choose the correct characters as they type, and press Enter to confirm each part. Once the full prompt is ready, pressing Enter sends it to the AI.

Previously, on macOS, the prompt would be sent immediately when Enter was pressed during an ongoing IME composition.

To address this, this PR adds a check for the event.isComposing property in the onKeyDown handler. This ensures that pressing Enter during composition does not trigger the send action. The message will now only be submitted once the composition is complete.
