### PR TITLE
Allow empty prompts with attachments

### DIFF
--- a/src/services/assistant.ts
+++ b/src/services/assistant.ts
@@ -82,9 +82,9 @@ export default class extends Generator {
 
   async prompt(prompt: string, opts: AssistantCompletionOpts, llmCallback: LlmChunkCallback, generationCallback?: GenerationCallback): Promise<GenerationResult> {
 
-    // check
+    // we need a prompt or at least attachments
     prompt = prompt.trim()
-    if (prompt === '') {
+    if (prompt === '' && (!opts.attachments || opts.attachments.length === 0)) {
       return null
     }
 

--- a/tests/unit/assistant.test.ts
+++ b/tests/unit/assistant.test.ts
@@ -69,7 +69,7 @@ const prompt = async (prompt: string, opts: AssistantCompletionOpts = { model: '
   
   // call and wait
   await assistant!.prompt(prompt, opts, callback)
-  await vi.waitUntil(async () => !assistant!.chat.lastMessage().transient)
+  await vi.waitUntil(async () => !assistant!.chat.lastMessage()?.transient)
 
   // return
   return content
@@ -242,6 +242,20 @@ test('Assistant sends attachment', async () => {
   ]})
   expect(assistant!.chat.messages[1].attachments).toHaveLength(2)
   expect(content).toBe('[{"role":"system","content":"instructions.chat.standard.fr-FR"},{"role":"user","content":"Hello LLM (image_content) (file_content)"},{"role":"assistant","content":"Be kind. Don\'t mock me"}]')
+})
+
+test('Assistant sends attachment with empty prompt', async () => {
+  const content = await prompt('', { model: 'chat', attachments: [
+    new Attachment('image_content', 'image/png', 'clipboard://', false),
+    new Attachment('file_content', 'text/plain', 'clipboard://', false)
+  ]})
+  expect(assistant!.chat.messages[1].attachments).toHaveLength(2)
+  expect(content).toBe('[{"role":"system","content":"instructions.chat.standard.fr-FR"},{"role":"user","content":" (image_content) (file_content)"},{"role":"assistant","content":"Be kind. Don\'t mock me"}]')
+})
+
+test('Assistant ignores empty prompt', async () => {
+  const content = await prompt('')
+  expect(content).toBe('')
 })
 
 test('Assistant System Expert', async () => {


### PR DESCRIPTION
This change allows sending prompts which only contain an attachment but no text prompt. Currently, the UI happily passes along the empty prompt but the assistant will silently ignore it. 

This is useful if you want to use an assistant with a system prompt like "I'll upload images of X and you'll do Y" without having to send a dummy text prompt along with each image.


