### PR TITLE
feat(shortcuts): Wayland-aware toggle (default off on Wayland)

### DIFF
--- a/src/main/shortcuts.ts
+++ b/src/main/shortcuts.ts
@@ -18,6 +18,18 @@ export const registerShortcuts = (app: App, callbacks: ShortcutCallbacks): void 
   // load the config
   const config = loadSettings(app);
 
+  // minimal Wayland/Toggle guard
+  // treat as Wayland on Linux if XDG_SESSION_TYPE says 'wayland' or WAYLAND_DISPLAY is present
+  const isWayland = process.platform === 'linux' && ((process.env.XDG_SESSION_TYPE?.toLowerCase?.() === 'wayland') || !!process.env.WAYLAND_DISPLAY);
+  const enableGlobalShortcuts = (config.shortcuts as any).enableGlobalShortcuts !== undefined
+    ? (config.shortcuts as any).enableGlobalShortcuts
+    : !isWayland;
+
+  if (!enableGlobalShortcuts) {
+    console.info('Global shortcuts disabled by settings/Wayland');
+    return;
+  }
+
   // now register
   console.info('Registering shortcuts')
   registerShortcut('prompt', config.shortcuts.prompt, callbacks.prompt);

--- a/src/settings/SettingsShortcuts.vue
+++ b/src/settings/SettingsShortcuts.vue
@@ -42,6 +42,11 @@
         <label>{{ t('settings.shortcuts.voiceMode') }}</label>
         <InputShortcut v-model="realtime" @change="save" />
       </div>
+
+      <div class="form-field horizontal">
+        <input type="checkbox" v-model="enableGlobalShortcuts" @change="onToggleGlobalShortcuts" />
+        <label>Enable global shortcuts</label>
+      </div>
     </main>
   </div>
 </template>
@@ -61,6 +66,7 @@ const readaloud = ref(null)
 const transcribe = ref(null)
 const realtime = ref(null)
 const studio = ref(null)
+const enableGlobalShortcuts = ref(false)
 
 const load = () => {
   prompt.value = store.config.shortcuts.prompt
@@ -71,6 +77,7 @@ const load = () => {
   transcribe.value = store.config.shortcuts.transcribe
   realtime.value = store.config.shortcuts.realtime
   studio.value = store.config.shortcuts.studio
+  enableGlobalShortcuts.value = store.config.shortcuts.enableGlobalShortcuts ?? enableGlobalShortcuts.value
 }
 
 const save = () => {
@@ -82,6 +89,12 @@ const save = () => {
   store.config.shortcuts.transcribe = transcribe.value
   store.config.shortcuts.realtime = realtime.value
   store.config.shortcuts.studio = studio.value
+  store.saveSettings()
+  window.api.shortcuts.register()
+}
+
+const onToggleGlobalShortcuts = () => {
+  store.config.shortcuts.enableGlobalShortcuts = enableGlobalShortcuts.value
   store.saveSettings()
   window.api.shortcuts.register()
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,7 +2,7 @@
 import { ChatModel, EngineCreateOpts, Model, LlmModelOpts } from 'multi-llm-ts'
 import { DesignStudioMediaType, Shortcut, strDict, TTSVoice } from './index'
 import { PluginConfig } from '../plugins/plugin'
-import { McpClaudeServer, McpServer, McpServerState, McpOAuthConfig } from './mcp'
+import { McpClaudeServer, McpServer, McpServerState } from './mcp'
 import { ToolSelection } from './llm'
 
 export type Configuration = {
@@ -95,7 +95,6 @@ export type LLMConfig = {
   defaults: ModelDefaults[]
   customInstructions: CustomInstruction[]
   additionalInstructions: {
-    toolRetry: boolean
     datetime: boolean
     mermaid: boolean
     artifacts: boolean
@@ -163,15 +162,12 @@ export type AutomationConfig = {
 
 export type ChatToolMode = 'never' | 'calling' | 'always'
 
-export type TextFormat = 'text' | 'markdown'
-
 export type ChatAppearance = {
   showReasoning: boolean
   theme: string
   fontFamily: string
   fontSize: number
   showToolCalls: ChatToolMode
-  copyFormat: TextFormat
 }
 
 export type ChatListMode = 'timeline' | 'folder'
@@ -193,6 +189,8 @@ export type ShortcutsConfig = {
   realtime: Shortcut
   studio: Shortcut
   forge: Shortcut
+  // optional Flag: globale Shortcuts (Default-Logik erfolgt zur Laufzeit in main/shortcuts.ts)
+  enableGlobalShortcuts?: boolean
 }
 
 export type ScratchpadConfig = {
@@ -230,8 +228,13 @@ export type STTConfig = {
     gpu: boolean
   }
   soniox?: {
+    languageHints?: string[]
+    endpointDetection?: boolean
     cleanup?: boolean
     audioFormat?: string
+    proxy?: 'temporary_key' | 'proxy_stream'
+    tempKeyExpiry?: number
+    speakerDiarization?: boolean
   }
   //silenceAction: SilenceAction
 }
@@ -286,7 +289,6 @@ export type RagConfig = {
 export type McpServerExtra = {
   label?: string
   state?: McpServerState
-  oauth?: McpOAuthConfig
 }
 
 export type McpConfig = {
@@ -295,4 +297,3 @@ export type McpConfig = {
   mcpServersExtra: Record<string, McpServerExtra>
   smitheryApiKey: string
 }
-


### PR DESCRIPTION
This PR adds a toggle in the UI to disable Wayland shortcuts by default due to persistent instability issues observed across multiple Ubuntu workstations. While shortcuts work intermittently at best, sometimes failing entirely or behaving unpredictably, they also broke GNOME’s functionality (e.g., shortcuts for copy-paste) system-wide on some installations, rendering not just Witsy but all applications unusable.
 
The default state is now off on Wayland, but users can re-enable it via the UI if needed. This change minimizes disruption while keeping the option accessible.
 
The code ive written approx 2 weeks ago. I did linting, testing and my daily usage, and repeatedly updated to align with the latest release.
 