### PR TITLE
feat(http): minimal local HTTP trigger

### DIFF
--- a/src/main/httpServer.ts
+++ b/src/main/httpServer.ts
@@ -1,0 +1,124 @@
+import http from 'node:http';
+import { URL } from 'node:url';
+
+let server: http.Server | null = null;
+
+/**
+ * Minimal local HTTP trigger server (localhost-only, no auth).
+ *
+ * Endpoints:
+ * - GET  /health
+ *     Response: { ok: true }
+ *
+ * - GET  /trigger?cmd=<string>&text=<string>
+ *   or
+ * - POST /trigger           (Content-Type: application/json)
+ *     Body: { "cmd": "<string>", "text": "<string>" }
+ *
+ * Supported cmd values:
+ *   prompt | chat | scratchpad | command | readaloud | transcribe | realtime | studio | forge
+ *
+ * Text handling:
+ *   - If provided, 'text' is forwarded to the handler so the main process can use putCachedText(text)
+ *     and open the appropriate window (e.g., Prompt Anywhere with promptId, Command Picker with textId).
+ *
+ * Notes:
+ *   - Keep this server minimal by design (no external deps, no auth, 127.0.0.1 binding).
+ *   - For long or multi-line texts, prefer POST/JSON.
+ *   - Logging: each request is logged with cmd and text length.
+ */
+export const start = (
+  port: number,
+  handler: (cmd: string, params?: { text?: string }) => Promise<boolean> | boolean
+): boolean => {
+  if (server) {
+    return true;
+  }
+  try {
+    server = http.createServer((req, res) => {
+      const host = req.headers.host || `127.0.0.1:${port}`;
+      const url = new URL(req.url || '/', `http://${host}`);
+      res.setHeader('Content-Type', 'application/json');
+
+      const respond = (status: number, obj: any) => {
+        res.statusCode = status;
+        res.end(JSON.stringify(obj));
+      };
+
+      // Health endpoint
+      if (req.method === 'GET' && url.pathname === '/health') {
+        return respond(200, { ok: true });
+      }
+
+      if (url.pathname === '/trigger' && (req.method === 'GET' || req.method === 'POST')) {
+
+        const finalize = async (cmd: string, params: { text?: string }) => {
+          let ok = false;
+          if (cmd) {
+            try {
+              ok = await Promise.resolve(handler(cmd, params));
+            } catch {
+              ok = false;
+            }
+          }
+          return respond(ok ? 200 : 400, { success: ok, cmd });
+        };
+
+        if (req.method === 'GET') {
+          const cmd = url.searchParams.get('cmd') || '';
+          const text = url.searchParams.get('text') || undefined;
+          console.info(`[http-trigger] GET /trigger cmd=${cmd} textLen=${(text || '').length}`);
+          return finalize(cmd, { text });
+        }
+
+        // POST JSON payload
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+          if (body.length > 1e6) {
+            req.socket.destroy();
+          }
+        });
+        req.on('end', () => {
+          try {
+            const json = body ? JSON.parse(body) : {};
+            const cmd = (json?.cmd ?? '').toString();
+            const text = typeof json?.text === 'string' ? json.text : undefined;
+            console.info(`[http-trigger] POST /trigger cmd=${cmd} textLen=${text ? text.length : 0}`);
+            finalize(cmd, { text });
+          } catch {
+            respond(400, { success: false, error: 'INVALID_JSON' });
+          }
+        });
+        return;
+      }
+
+      // Not found
+      respond(404, { success: false, error: 'NOT_FOUND' });
+    }).listen(port, '127.0.0.1');
+
+    server.on('error', (err: any) => {
+      console.warn('HTTP server error:', err?.message || err);
+    });
+
+    console.info(`HTTP trigger server listening on http://127.0.0.1:${port}`);
+    return true;
+  } catch (e) {
+    console.warn('Failed to start HTTP server:', e);
+    server = null;
+    return false;
+  }
+};
+
+export const stop = (): void => {
+  if (server) {
+    try {
+      const s = server;
+      server = null;
+      s.close();
+      console.info('HTTP trigger server stopped');
+    } catch {
+      /* empty */
+    }
+  }
+};

--- a/src/settings/SettingsAdvanced.vue
+++ b/src/settings/SettingsAdvanced.vue
@@ -34,6 +34,12 @@
           <option value="2048">{{ t('settings.advanced.imageResizeOptions.size', { size: 2048 }) }}</option>
         </select>
       </div>
+
+      <div class="form-field horizontal">
+        <input type="checkbox" v-model="httpServerEnabled" @change="save" />
+        <label>Enable local HTTP trigger</label>
+      </div>
+
       <div class="form-field instruction">
         <label>{{ t('settings.advanced.systemInstructions') }}</label>
         <div class="form-subgroup">
@@ -85,12 +91,14 @@ const autoSavePrompt = ref(null)
 const proxyMode = ref<ProxyMode>('default')
 const customProxy = ref('')
 const imageResize = ref(null)
+const httpServerEnabled = ref(false)
 
 const load = () => {
   autoSavePrompt.value = store.config.prompt.autosave
   proxyMode.value = store.config.general.proxyMode
   customProxy.value = store.config.general.customProxy
   imageResize.value = store.config.llm.imageResize ?? 768
+  httpServerEnabled.value = store.config.httpServerEnabled ?? false
   onChangeInstructions()
 }
 
@@ -111,6 +119,7 @@ const save = () => {
   store.config.general.proxyMode = proxyMode.value
   store.config.general.customProxy = customProxy.value
   store.config.llm.imageResize = parseInt(imageResize.value)
+  store.config.httpServerEnabled = httpServerEnabled.value
 
   // update prompt
   const defaultInstructions = i18nInstructions(null, instructions.value)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,7 +2,7 @@
 import { ChatModel, EngineCreateOpts, Model, LlmModelOpts } from 'multi-llm-ts'
 import { DesignStudioMediaType, Shortcut, strDict, TTSVoice } from './index'
 import { PluginConfig } from '../plugins/plugin'
-import { McpClaudeServer, McpServer, McpServerState, McpOAuthConfig } from './mcp'
+import { McpClaudeServer, McpServer, McpServerState } from './mcp'
 import { ToolSelection } from './llm'
 
 export type Configuration = {
@@ -25,6 +25,9 @@ export type Configuration = {
   realtime: RealtimeConfig
   mcp: McpConfig
   mcpServers: Record<string, McpClaudeServer>
+  // PR2: optional local HTTP trigger settings
+  httpServerEnabled?: boolean
+  httpServerPort?: number
   features?: Record<string, any>
 }
 
@@ -95,7 +98,6 @@ export type LLMConfig = {
   defaults: ModelDefaults[]
   customInstructions: CustomInstruction[]
   additionalInstructions: {
-    toolRetry: boolean
     datetime: boolean
     mermaid: boolean
     artifacts: boolean
@@ -163,15 +165,12 @@ export type AutomationConfig = {
 
 export type ChatToolMode = 'never' | 'calling' | 'always'
 
-export type TextFormat = 'text' | 'markdown'
-
 export type ChatAppearance = {
   showReasoning: boolean
   theme: string
   fontFamily: string
   fontSize: number
   showToolCalls: ChatToolMode
-  copyFormat: TextFormat
 }
 
 export type ChatListMode = 'timeline' | 'folder'
@@ -230,8 +229,13 @@ export type STTConfig = {
     gpu: boolean
   }
   soniox?: {
+    languageHints?: string[]
+    endpointDetection?: boolean
     cleanup?: boolean
     audioFormat?: string
+    proxy?: 'temporary_key' | 'proxy_stream'
+    tempKeyExpiry?: number
+    speakerDiarization?: boolean
   }
   //silenceAction: SilenceAction
 }
@@ -286,7 +290,6 @@ export type RagConfig = {
 export type McpServerExtra = {
   label?: string
   state?: McpServerState
-  oauth?: McpOAuthConfig
 }
 
 export type McpConfig = {
@@ -295,4 +298,3 @@ export type McpConfig = {
   mcpServersExtra: Record<string, McpServerExtra>
   smitheryApiKey: string
 }
-


### PR DESCRIPTION
This PR introduces a minimal local HTTP server to handle shortcut commands and receiving of text selections via a REST interface, ensuring Wayland compliance by triggering shortcuts through CLI instead of direct input capture. The solution decouples Witsy from Wayland’s unstable shortcut handling while maintaining full functionality, while not sacrifing the witsy cli. This should work on every platform.

I kept the changes absolutely minimal. Believe such an interface could do much more, but wanted to keep the PR acceptable.

The server listens for local requests, validates payloads, and executes the corresponding actions. For testing, the latest release with this feature active is available at [maintained-main](https://github.com/tisDDM/witsy/tree/maintained-main).

The standalone trigger receiver, developed as part of this effort, is available at [wbridge](https://github.com/DasDigitaleMomentum/wbridge). That receiver I have written because I wanted to do a proof-of-concept of GPT-5 together with Cline with its new features.
I did linting, testing, and real-world usage and found it stable.